### PR TITLE
Don't sleep on single offer scraping

### DIFF
--- a/ceneoscraper/bs4_scraper.py
+++ b/ceneoscraper/bs4_scraper.py
@@ -310,8 +310,8 @@ def get_offers(website_link):
             }
         )
         counter += 1
-    time.sleep(6)
-
+    if len(offers) != 1:
+        time.sleep(6)
     return offer_list
 
 


### PR DESCRIPTION
When a single product offer is found, `get_offers` is called in `get_products`. Because of that, our sleep function was triggered when searching for products unnecessarily.